### PR TITLE
Dev: Fix #4

### DIFF
--- a/KC.Backend.API/Controllers/GamePlayController.cs
+++ b/KC.Backend.API/Controllers/GamePlayController.cs
@@ -29,7 +29,7 @@ public class GamePlayController(IGamePlayLogic gamePlayLogic, ISessionLogic sess
         }
         catch (Exception e)
         {
-            Debug.WriteLine(e);
+            Debug.WriteLine($"Failed to get possible actions on hand for session {dto.sessionId}: {e}");
             nextPossibleMoves = [];
         }
         

--- a/KC.Backend.API/Controllers/GamePlayController.cs
+++ b/KC.Backend.API/Controllers/GamePlayController.cs
@@ -22,7 +22,17 @@ public class GamePlayController(IGamePlayLogic gamePlayLogic, ISessionLogic sess
     {
         moveOrchestrator.MakeMove(MacAddress.Parse(macAddress), dto);
         var session = sessionLogic.Get(dto.sessionId);
-        var nextPossibleMoves = gamePlayLogic.GetPossibleActionsOnHand(dto.sessionId, session.CurrentTurnInfo.BoxIdx, session.CurrentTurnInfo.HandIdx).ToArray();
+        Move[] nextPossibleMoves;
+        try
+        {
+            nextPossibleMoves = gamePlayLogic.GetPossibleActionsOnHand(dto.sessionId, session.CurrentTurnInfo.BoxIdx, session.CurrentTurnInfo.HandIdx).ToArray();
+        }
+        catch (Exception e)
+        {
+            Debug.WriteLine(e);
+            nextPossibleMoves = [];
+        }
+        
         if (nextPossibleMoves.Length == 0 || nextPossibleMoves.All(m => m == Move.Stand))
         {
             gamePlayLogic.TransferTurn(dto.sessionId);


### PR DESCRIPTION
This pull request introduces improved error handling to the `MakeMove` method in the `GamePlayController`. The main change ensures that if an exception occurs while fetching the next possible moves, the error is logged and the system continues gracefully with an empty move list, preventing potential crashes or unhandled exceptions.

**Error handling improvements:**

* Wrapped the call to `gamePlayLogic.GetPossibleActionsOnHand` in a try-catch block, logging any exceptions and defaulting `nextPossibleMoves` to an empty array if an error occurs.