### PR TITLE
Changing auto-release to work on release branch instead of main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,11 +2,11 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - release
 
 jobs:
   run_push:
-    name: Push on master -> deploy
+    name: Push on release -> deploy
     runs-on: ubuntu-latest
 
     steps:
@@ -49,7 +49,7 @@ jobs:
             {
               echo "set -e"
               echo "cd ~/King-of-the-Cards"
-              echo "git checkout master"
+              echo "git checkout release"
               echo "git pull"
               echo "sudo systemctl restart kc-backend.service"
             } | ssh -o ConnectTimeout=10 ${{ secrets.SSH_USER }}@172.16.0.1 && break || sleep 5


### PR DESCRIPTION
This pull request updates the deployment workflow to use the `release` branch instead of the `master` branch. The workflow and deployment steps are now triggered and executed based on changes to the `release` branch.

Deployment workflow updates:

* The workflow trigger in `.github/workflows/main.yml` is changed to run on pushes to the `release` branch instead of `master`.
* The deployment job now checks out the `release` branch and deploys it, rather than the `master` branch.